### PR TITLE
Rebuild ALFR3D pricing around the 5-SKU ladder (Core, Nexus Launcher,…

### DIFF
--- a/conf/tailwind.config.js
+++ b/conf/tailwind.config.js
@@ -13,7 +13,8 @@ module.exports = {
         },
         accent: {
           amber: '#F7C948',
-          cyan: '#22D3EE'
+          cyan: '#22D3EE',
+          magenta: '#E93DE9'
         },
         bg: {
           charcoal: '#0A0D13',

--- a/src/alfr3d.pug
+++ b/src/alfr3d.pug
@@ -27,11 +27,10 @@ body.text-white.grid-bg
         +section(product)
 
     section.border-t.border-gray-800(data-scroll-section, class='py-16 px-8')
-      .max-w-screen-lg.mx-auto.flex.items-center.justify-between.flex-wrap(class='gap-8')
-        div
-          h3.font-display.font-bold.text-gray-300(class='text-2xl') #{alfr3d.kit.title}
-          p.font-mono.italic.text-gray-400.mt-2(class='text-xs md:text-sm opacity-80') “#{alfr3d.kit.quip}”
-          p.text-gray-500.mt-2(class='text-sm max-w-lg') #{alfr3d.kit.text}
-        span.inline-block.border.border-gray-700.text-gray-500.rounded-full(class='text-xs tracking-widest uppercase px-4 py-2') #{alfr3d.kit.badge}
+      .max-w-screen-lg.mx-auto.space-y-6
+        for note in alfr3d.commerceNotes
+          div
+            h3.font-display.font-bold.text-gray-300(class='text-lg') #{note.title}
+            p.text-gray-500.mt-2(class='text-sm max-w-2xl leading-relaxed') #{note.text}
 
     +siteFooter(footer, { href: 'index.html', text: '← Littl3.1 Engineering' })

--- a/src/content.yml
+++ b/src/content.yml
@@ -64,7 +64,40 @@ alfr3d:
     cta:
       text: → See the full timeline
       href: timeline.html
+  commerceNotes:
+    - title: Open source, actually
+      text: "Licensed FSL-1.1-ALv2: you can run it, modify it, and never pay us. The one thing you can't do is resell hosted ALFR3D as a competing service — and even that restriction expires after two years, at which point the license converts to Apache 2.0."
+    - title: The Relay commitment
+      text: "Relay access is included for the life of your Kit. If we ever discontinue the hosted relay, we'll open-source the relay server so you can run your own instead of losing the feature outright."
   products:
+    - title: Alfr3d Kit
+      id: p-kit
+      eyebrow: / ALFR3D KIT
+      accent: magenta
+      wide: true
+      badge:
+        text: Founding batch open — 100 units
+        accent: magenta
+      quip: A butler, boxed and ready to ship. Numbered, not mass-produced.
+      lines:
+        - "A Raspberry Pi, pre-flashed with ALFR3D Core and shipped ready to plug in — no Docker Compose, no manual setup, just power and a network connection. Built to order, not stocked."
+        - "The lead way to get ALFR3D: every Kit ships with a lifetime Relay connection and Nexus Launcher Pro unlocked for free. The first 100 units are numbered, and come with a direct line to me for support instead of a ticket queue."
+      pricing:
+        - amount: $399
+          label: Founding 100 · one-time
+          accent: magenta
+          badge: Limited — first 100 only
+          info: 'A numbered unit (e.g. "#014 of 100"), lifetime Relay included for as long as you own the Kit, Nexus Launcher Pro unlocked free, and direct founder support. Once all 100 ship, this price is gone for good — it becomes the $449 steady-state price below.'
+          cta:
+            text: → Reserve by email
+            href: 'mailto:athos@littl31.com?subject=Alfr3d%20Kit%20%E2%80%94%20Founding%20100%20reservation'
+          note: 'Ships by [date TBD — no ship date committed yet]'
+        - amount: $449
+          label: Steady-state · one-time
+          info: The same Kit, same lifetime Relay, same free Nexus Launcher Pro — the ongoing price once all 100 founding units are gone.
+          cta:
+            text: → Join the waitlist
+            href: 'mailto:athos@littl31.com?subject=Alfr3d%20Kit%20%E2%80%94%20waitlist'
     - title: Nexus Launcher
       id: p-launcher
       eyebrow: / NEXUS LAUNCHER
@@ -83,7 +116,10 @@ alfr3d:
         - amount: $5.99
           label: Pro unlock · one-time, Play Billing
           accent: orange
-          info: One-time purchase through Google Play Billing — not a subscription, no tiers. Unlocks extra themes and icon packs, advanced window layouts (snap presets, multi-window save/restore), and layout backup & restore.
+          info: One-time purchase through Google Play Billing — not a subscription. Unlocks extra themes and icon packs, advanced window layouts (snap presets, multi-window save/restore), and layout backup & restore. Free automatically if you own an Alfr3d Kit or subscribe to Butler — no separate purchase needed.
+          cta:
+            text: → Notify me on Google Play
+            href: 'mailto:athos@littl31.com?subject=Nexus%20Launcher%20Pro%20%E2%80%94%20notify%20me'
     - title: ALFR3D Core
       id: p-core
       eyebrow: / ALFR3D CORE
@@ -93,34 +129,61 @@ alfr3d:
       quip: The engine room. I keep it running so you never have to think about it.
       lines:
         - "The backend: containerized microservices — API, User, Device, Environment, and Speak — each one independent, coordinating only over Kafka, plus a Python daemon that handles situational awareness and voice routing. The result is a dashboard that actually looks like something you'd want on a wall panel — not a spreadsheet."
-        - Stays free forever, stays self-hosted, stays local-first. This is the platform, not the product we're selling — think of it the way Home Assistant thinks of Home Assistant Core.
-    - title: ALFR3D Cloud
-      id: p-cloud
-      eyebrow: / ALFR3D CLOUD
-      badge:
-        text: Coming — Phase 3
-        accent: gray
-      quip: I'll forward your calls when you're away. I still won't forward your secrets.
-      lines:
-        - A thin, dumb-pipe relay for remote access and push — it never sees your home's plaintext data. Reach your house from anywhere without opening a port on your router.
-        - Benchmarked against Nabu Casa — a fair price for infrastructure we run, on top of a platform that costs nothing to run yourself.
-      wide: true
+        - Stays free forever, stays self-hosted, stays local-first, no feature ceiling. This is the platform, not the product we're selling — think of it the way Home Assistant thinks of Home Assistant Core.
       pricing:
         - amount: Free
-          label: Local-only, always available
-          info: Local network only — everything ALFR3D does today. No relay, no account, no monthly fee. This tier isn't going away.
-        - amount: $5.99/mo
-          label: Cloud · remote access, push
-          info: Or $59/yr. Remote access relay — no port-forwarding — plus push notifications to the launcher and phone. Benchmarked against Nabu Casa (~$6.50/mo), the closest real precedent for this model.
-        - amount: $11.99/mo
-          label: Cloud+ · hosted backups, personality features, priority support
-          accent: orange
-          info: Or $119/yr. Everything in Cloud, plus hosted backups, the LLM-powered personality/quips features, and a priority support queue — real per-user compute cost behind each of those.
-  kit:
-    title: ALFR3D Kit
-    quip: A butler, boxed and ready to ship. Currently interviewing for the position — do check back.
-    text: "A Raspberry Pi, pre-flashed with ALFR3D Core and shipped ready to plug in — no Docker Compose, no manual setup, just power and a network connection. It's built to order, not stocked. Development hasn't started: the Kit only makes sense once enough people are running Cloud to justify building hardware for them, not before."
-    badge: Not yet scheduled
+          label: Full platform, forever
+          info: Self-hosted, local-first, updates included forever. Licensed FSL-1.1-ALv2 — run it and modify it without paying us a cent.
+      cta:
+        text: → View on GitHub
+        href: 'https://github.com/Littl3-1-Engineering/alfr3d'
+    - title: Relay
+      id: p-relay
+      eyebrow: / RELAY
+      accent: cyan
+      quip: I'll forward your calls when you're away. I still won't forward your secrets.
+      lines:
+        - "A thin, dumb-pipe relay for remote access — no port-forwarding, no plaintext ever passing through our servers. Reach your house from anywhere without opening your router to the internet."
+        - Included free for the life of your Kit, and free with a Butler subscription. Relay standalone is for Core users who just want remote access without anything else.
+      wide: true
+      pricing:
+        - amount: $2.99/mo
+          label: Relay · monthly
+          info: Remote access only — no push, no hosted backups, no personality features. Included free with any Alfr3d Kit or a Butler subscription.
+          cta:
+            text: → Join the Relay waitlist
+            href: 'mailto:athos@littl31.com?subject=Alfr3d%20Relay%20%E2%80%94%20waitlist'
+        - amount: $29/yr
+          label: Relay · annual
+          badge: Save vs. monthly
+          info: Same Relay, billed yearly — about 19% off the monthly rate.
+          cta:
+            text: → Join the Relay waitlist
+            href: 'mailto:athos@littl31.com?subject=Alfr3d%20Relay%20%E2%80%94%20waitlist%20(annual)'
+    - title: Butler
+      id: p-butler
+      eyebrow: / BUTLER
+      right: true
+      accent: magenta
+      quip: I remember your errands, your appointments, and exactly how you like your coffee. Butler edition me, anyway.
+      lines:
+        - "The one subscription: Relay's remote access, plus push notifications, hosted encrypted backups, and the personality/quips layer that makes ALFR3D feel less like a control panel and more like staff."
+        - Fair-use LLM usage included — generous, capped to keep it sustainable, not throttled to nudge you into a bigger plan. Priority support included.
+      pricing:
+        - amount: $99/yr
+          label: Butler · annual
+          accent: magenta
+          badge: Recommended
+          info: Works out to about $8.25/mo — two months free versus paying monthly. Relay + push + hosted encrypted backups + personality/quips (fair-use capped) + priority support.
+          cta:
+            text: → Join the Butler waitlist
+            href: 'mailto:athos@littl31.com?subject=Alfr3d%20Butler%20%E2%80%94%20waitlist%20(annual)'
+        - amount: $9.99/mo
+          label: Butler · monthly
+          info: Same inclusions as annual, billed monthly.
+          cta:
+            text: → Join the Butler waitlist
+            href: 'mailto:athos@littl31.com?subject=Alfr3d%20Butler%20%E2%80%94%20waitlist'
 
 timeline:
   meta:

--- a/src/css/theme.styl
+++ b/src/css/theme.styl
@@ -154,6 +154,8 @@ tab-clip(big, small)
 	--accent-solid #FFA500
 .accent-gray
 	--accent-solid #9CA3AF
+.accent-magenta
+	--accent-solid #E93DE9
 
 .accent-text-amber
 	color #F7C948
@@ -163,6 +165,8 @@ tab-clip(big, small)
 	color #FFA500
 .accent-text-gray
 	color #9CA3AF
+.accent-text-magenta
+	color #E93DE9
 
 .accent-border-amber
 	border-color #F7C948
@@ -172,3 +176,5 @@ tab-clip(big, small)
 	border-color #FFA500
 .accent-border-gray
 	border-color #9CA3AF
+.accent-border-magenta
+	border-color #E93DE9

--- a/src/mixins.pug
+++ b/src/mixins.pug
@@ -135,29 +135,36 @@ mixin section(item, defaultAccent)
                     class='transition-opacity delay-100 duration-700 text-gray-300 leading-relaxed'
                   )= line
 
-              if item.pricing
-                .flex.flex-wrap.pt-2(class='gap-6')
-                  for tier in item.pricing
-                    - var tierAccent = tier.accent || accent
-                    .group.relative
-                      .window-frame.window-sm(class=`accent-${tierAccent}`)
-                        .window-body
-                          .window-content(class='px-6 py-4')
-                            .flex.items-center.gap-2
-                              div.font-bold(class=`accent-text-${tierAccent} text-3xl`)= tier.amount
-                              if tier.info
-                                button(
-                                  type='button',
-                                  aria-label=`More info — ${tier.label}`,
-                                  data-pricing-info-toggle,
-                                  class='flex-shrink-0 w-5 h-5 rounded-full border border-gray-500 text-gray-400 text-xs italic font-bold leading-none flex items-center justify-center hover:border-amber-400 hover:text-amber-400 focus:outline-none focus:border-amber-400 focus:text-amber-400 transition-colors'
-                                ) i
-                            div.text-xs.text-gray-400.mt-1= tier.label
-                      if tier.info
-                        .pricing-info-popover(
-                          data-pricing-info-popover,
-                          class=`info-popover accent-border-${tierAccent} absolute left-0 top-full mt-2 w-72 p-4 border text-sm text-gray-300 leading-relaxed opacity-0 pointer-events-none transition-opacity duration-200 z-20 group-hover:opacity-100 group-hover:pointer-events-auto`
-                        )= tier.info
+          if item.pricing
+            .flex.flex-wrap.pt-6(class='gap-6')
+              for tier in item.pricing
+                - var tierAccent = tier.accent || accent
+                .group.relative
+                  if tier.badge
+                    span.absolute.whitespace-nowrap(class=`accent-border-${tierAccent} accent-text-${tierAccent} text-xs tracking-widest uppercase border rounded-full px-3 py-1 bg-gray-900`, style='top: -0.85rem; left: 50%; transform: translateX(-50%); z-index: 10;')= tier.badge
+                  .window-frame.window-sm(class=`accent-${tierAccent}`)
+                    .window-body
+                      .window-content(class='px-6 py-4')
+                        .flex.items-center.gap-2
+                          div.font-bold(class=`accent-text-${tierAccent} text-3xl`)= tier.amount
+                          if tier.info
+                            button(
+                              type='button',
+                              aria-label=`More info — ${tier.label}`,
+                              data-pricing-info-toggle,
+                              class='flex-shrink-0 w-5 h-5 rounded-full border border-gray-500 text-gray-400 text-xs italic font-bold leading-none flex items-center justify-center hover:border-amber-400 hover:text-amber-400 focus:outline-none focus:border-amber-400 focus:text-amber-400 transition-colors'
+                            ) i
+                        div.text-xs.text-gray-400.mt-1= tier.label
+                        if tier.cta
+                          p.mt-3
+                            a.text-xs(href=tier.cta.href, class=`btn-glow accent-${tierAccent}`, style='padding: 0.4rem 1rem;')= tier.cta.text
+                        if tier.note
+                          p.text-xs.text-gray-500.mt-2.italic= tier.note
+                  if tier.info
+                    .pricing-info-popover(
+                      data-pricing-info-popover,
+                      class=`info-popover accent-border-${tierAccent} absolute left-0 top-full mt-2 w-72 p-4 border text-sm text-gray-300 leading-relaxed opacity-0 pointer-events-none transition-opacity duration-200 z-20 group-hover:opacity-100 group-hover:pointer-events-auto`
+                    )= tier.info
 
           if item.cta
             p.pt-2


### PR DESCRIPTION
… Kit, Relay, Butler)

Retires Cloud/Cloud+ in favor of Kit (Founding 100 / steady-state), standalone Relay, and Butler (the one subscription). Promotes Kit into the shared product-card mixin as the visual hero, adds per-tier badge/CTA/note support and a magenta accent token, adds the FSL-1.1-ALv2 and Relay-commitment explainer paragraphs, and gives every priced tier a CTA (mailto placeholders pending Stripe/Play Store).

Also fixes a pre-existing bug where any product with an image (e.g. Nexus Launcher) never rendered its pricing tiers at all.